### PR TITLE
Updated redux-middleware-oneshot to version 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "react-native": "0.10.1",
     "redux-actions": "0.8.0",
-    "redux-middleware-oneshot": "0.1.0"
+    "redux-middleware-oneshot": "0.1.1"
   },
   "peerDependencies": {
     "redux": "^3.0.0 || ^2.0.0 || ^1.0.0 || 1.0.0-alpha || 1.0.0-rc"


### PR DESCRIPTION
:rocket:

redux-middleware-oneshot just published version 0.1.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 17 commits (ahead by 17, behind by 0).
- [f25362c](https://github.com/michaelcontento/redux-middleware-oneshot/commit/f25362cdcb2426047def59904f5721bbfa605d7d): Release 0.1.1
- [6c66c85](https://github.com/michaelcontento/redux-middleware-oneshot/commit/6c66c85b9f28a6bdec81d026db4fbb88aa8083f5): remove unused rm from `make clean`
- [eaa3e91](https://github.com/michaelcontento/redux-middleware-oneshot/commit/eaa3e91de524977087f797a6af4341882a262f2a): also trigger `make build` on `make ci`
- [4923a57](https://github.com/michaelcontento/redux-middleware-oneshot/commit/4923a5723a51e1e0cd8e8c6734358be916b8fdaa): Merge pull request #4 from michaelcontento/greenkeeper-eslint-config-airbnb-0.1.0
- [40ce2fe](https://github.com/michaelcontento/redux-middleware-oneshot/commit/40ce2fe0fa8e75afcaace43db0e9861c6aeeb877): add build badge to README
- [2093749](https://github.com/michaelcontento/redux-middleware-oneshot/commit/2093749971df68870680c6a9b33ead4b8c7a6321): use `make ci` as `npm test`
- [76f22ae](https://github.com/michaelcontento/redux-middleware-oneshot/commit/76f22ae0a00154fa2f2c62bf4441a31c0716577d): update npmignore
- [4d7d215](https://github.com/michaelcontento/redux-middleware-oneshot/commit/4d7d215f2756f4f8c775576cbcf1eb31f3a45796): add travis.yml
- [4cd893f](https://github.com/michaelcontento/redux-middleware-oneshot/commit/4cd893f4bde400d7be85faef38ef886f22d9a581): update Makefile
- [83dec5e](https://github.com/michaelcontento/redux-middleware-oneshot/commit/83dec5e8874c9e724e4df13bfc6eac0ad0a30968): add editorconfig
- [077294b](https://github.com/michaelcontento/redux-middleware-oneshot/commit/077294b3d73d15bcb83889106c0b76852a4aea02): support redux 3.\* as peerDependencies
- [c767933](https://github.com/michaelcontento/redux-middleware-oneshot/commit/c767933dd7764ca36cc080b62262b4fb1418b43f): add missing eslint-plugin-react dependency
- [ca71c85](https://github.com/michaelcontento/redux-middleware-oneshot/commit/ca71c856e793f2ca733c27d4f1dd7cfcabb20c18): chore(package): update eslint-config-airbnb to version 0.1.0
- [2ff654e](https://github.com/michaelcontento/redux-middleware-oneshot/commit/2ff654e540934d5b81f5ab7b71beeecca412dc30): Merge pull request #3 from michaelcontento/greenkeeper-eslint-1.6.0
- [1c74f36](https://github.com/michaelcontento/redux-middleware-oneshot/commit/1c74f36c300ba6413c50b0bb07572703fcd4dfa0): chore(package): update eslint to version 1.6.0

There are 17 commits in total. See the [full diff](https://github.com/michaelcontento/redux-middleware-oneshot/compare/a972bcba99f06174948f8b459476b33b4e12acfd...f25362cdcb2426047def59904f5721bbfa605d7d).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
